### PR TITLE
add the overload of HiTSDB#deleteData() interfaces to support the optional field of "tags"

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/BalHiTSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/BalHiTSDBClient.java
@@ -630,24 +630,25 @@ public class BalHiTSDBClient implements HiTSDB {
 
     @Override
     public void deleteData(String metric, long startTime, long endTime) throws HttpUnknowStatusException {
-        Exception exception = null;
-        for (int i = 0; i < MAX_RETRY_SIZE; i++) {
-            try {
-                client().deleteData(metric, startTime, endTime);
-                return;
-            } catch (Exception e) {
-                exception = e;
-            }
-        }
-        throw new RuntimeException(exception);
+        deleteData(metric, null, null, startTime, endTime);
+    }
+
+    @Override
+    public void deleteData(String metric, Map<String, String> tags, long startTime, long endTime) throws HttpUnknowStatusException {
+        deleteData(metric, tags, null, startTime, endTime);
     }
 
     @Override
     public void deleteData(String metric, List<String> fields, long startTime, long endTime) throws HttpUnknowStatusException {
+        deleteData(metric, null, fields, startTime, endTime);
+    }
+
+    @Override
+    public void deleteData(String metric, Map<String, String> tags, List<String> fields, long startTime, long endTime) throws HttpUnknowStatusException {
         Exception exception = null;
         for (int i = 0; i < MAX_RETRY_SIZE; i++) {
             try {
-                client().deleteData(metric, fields, startTime, endTime);
+                client().deleteData(metric, tags, fields, startTime, endTime);
                 return;
             } catch (Exception e) {
                 exception = e;
@@ -658,24 +659,25 @@ public class BalHiTSDBClient implements HiTSDB {
 
     @Override
     public void deleteData(String metric, Date startDate, Date endDate) throws HttpUnknowStatusException {
-        Exception exception = null;
-        for (int i = 0; i < MAX_RETRY_SIZE; i++) {
-            try {
-                client().deleteData(metric, startDate, endDate);
-                return;
-            } catch (Exception e) {
-                exception = e;
-            }
-        }
-        throw new RuntimeException(exception);
+        deleteData(metric, null, null, startDate, endDate);
+    }
+
+    @Override
+    public void deleteData(String metric, Map<String, String> tags, Date startDate, Date endDate) throws HttpUnknowStatusException {
+        deleteData(metric, tags, null, startDate, endDate);
     }
 
     @Override
     public void deleteData(String metric, List<String> fields, Date startDate, Date endDate) throws HttpUnknowStatusException {
+        deleteData(metric, null, fields, startDate, endDate);
+    }
+
+    @Override
+    public void deleteData(String metric, Map<String, String> tags, List<String> fields, Date startDate, Date endDate) throws HttpUnknowStatusException {
         Exception exception = null;
         for (int i = 0; i < MAX_RETRY_SIZE; i++) {
             try {
-                client().deleteData(metric, fields, startDate, endDate);
+                client().deleteData(metric, tags, fields, startDate, endDate);
                 return;
             } catch (Exception e) {
                 exception = e;

--- a/src/main/java/com/aliyun/hitsdb/client/HiTSDB.java
+++ b/src/main/java/com/aliyun/hitsdb/client/HiTSDB.java
@@ -183,6 +183,16 @@ public interface HiTSDB extends Closeable {
 	 */
 	void deleteData(String metric, long startTime, long endTime) throws HttpUnknowStatusException;
 
+
+	/**
+	 * @param metric metric
+	 * @param tags tags that are under above metric
+	 * @param startTime start timestamp
+	 * @param endTime end timestamp
+	 * @throws HttpUnknowStatusException Exception
+	 */
+	void deleteData(String metric, Map<String, String> tags, long startTime, long endTime) throws HttpUnknowStatusException;
+
 	/**
 	 * @param metric metric
 	 * @param fields fields that are under above metric
@@ -191,6 +201,16 @@ public interface HiTSDB extends Closeable {
 	 * @throws HttpUnknowStatusException Exception
 	 */
 	void deleteData(String metric, List<String> fields, long startTime, long endTime) throws HttpUnknowStatusException;
+
+	/**
+	 * @param metric metric
+	 * @param tags tags that are under above metric
+	 * @param fields fields that are under above metric
+	 * @param startTime start timestamp
+	 * @param endTime end timestamp
+	 * @throws HttpUnknowStatusException Exception
+	 */
+	void deleteData(String metric, Map<String, String> tags, List<String> fields, long startTime, long endTime) throws HttpUnknowStatusException;
 
 	/**
 	 * for the api deleteDate
@@ -202,6 +222,15 @@ public interface HiTSDB extends Closeable {
 	void deleteData(String metric, Date startDate, Date endDate) throws HttpUnknowStatusException;
 
 	/**
+	 * @param metric metric
+	 * @param tags tags that are under above metric
+	 * @param startDate start date
+	 * @param endDate end date
+	 * @throws HttpUnknowStatusException Exception
+	 */
+	void deleteData(String metric, Map<String, String> tags, Date startDate, Date endDate) throws HttpUnknowStatusException;
+
+	/**
 	 * for the api deleteDate
 	 * @param metric metric name
 	 * @param fields fields that are under above metric
@@ -210,6 +239,16 @@ public interface HiTSDB extends Closeable {
 	 * @throws HttpUnknowStatusException Exception
 	 */
 	void deleteData(String metric, List<String> fields, Date startDate, Date endDate) throws HttpUnknowStatusException;
+
+	/**
+	 * @param metric metric
+	 * @param tags tags that are under above metric
+	 * @param fields fields that are under above metric
+	 * @param startDate start date
+	 * @param endDate end date
+	 * @throws HttpUnknowStatusException Exception
+	 */
+	void deleteData(String metric, Map<String, String> tags, List<String> fields, Date startDate, Date endDate) throws HttpUnknowStatusException;
 
 	/**
 	 * delete meta method

--- a/src/main/java/com/aliyun/hitsdb/client/HiTSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/HiTSDBClient.java
@@ -167,8 +167,24 @@ public class HiTSDBClient implements HiTSDB {
     }
 
     @Override
+    public void deleteData(String metric, Map<String, String> tags, long startTime, long endTime) {
+        MetricTimeRange metricTimeRange = new MetricTimeRange(metric, tags, startTime, endTime);
+        HttpResponse httpResponse = httpclient.post(HttpAPI.DELETE_DATA, metricTimeRange.toJSON());
+        ResultResponse resultResponse = ResultResponse.simplify(httpResponse, this.httpCompress);
+        handleVoid(resultResponse);
+    }
+
+    @Override
     public void deleteData(String metric, List<String> fields, long startTime, long endTime) {
         MetricTimeRange metricTimeRange = new MetricTimeRange(metric, fields, startTime, endTime);
+        HttpResponse httpResponse = httpclient.post(HttpAPI.DELETE_DATA, metricTimeRange.toJSON());
+        ResultResponse resultResponse = ResultResponse.simplify(httpResponse, this.httpCompress);
+        handleVoid(resultResponse);
+    }
+
+    @Override
+    public void deleteData(String metric, Map<String, String> tags, List<String> fields, long startTime, long endTime) {
+        MetricTimeRange metricTimeRange = new MetricTimeRange(metric, tags, fields, startTime, endTime);
         HttpResponse httpResponse = httpclient.post(HttpAPI.DELETE_DATA, metricTimeRange.toJSON());
         ResultResponse resultResponse = ResultResponse.simplify(httpResponse, this.httpCompress);
         handleVoid(resultResponse);
@@ -198,10 +214,24 @@ public class HiTSDBClient implements HiTSDB {
     }
 
     @Override
+    public void deleteData(String metric, Map<String, String> tags, Date startDate, Date endDate) {
+        long startTime = startDate.getTime();
+        long endTime = endDate.getTime();
+        deleteData(metric, tags, startTime, endTime);
+    }
+
+    @Override
     public void deleteData(String metric, List<String> fields, Date startDate, Date endDate) {
         long startTime = startDate.getTime();
         long endTime = endDate.getTime();
         deleteData(metric, fields, startTime, endTime);
+    }
+
+    @Override
+    public void deleteData(String metric, Map<String, String> tags, List<String> fields, Date startDate, Date endDate) {
+        long startTime = startDate.getTime();
+        long endTime = endDate.getTime();
+        deleteData(metric, tags, fields, startTime, endTime);
     }
 
     @Override

--- a/src/main/java/com/aliyun/hitsdb/client/value/request/MetricTimeRange.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/request/MetricTimeRange.java
@@ -3,9 +3,15 @@ package com.aliyun.hitsdb.client.value.request;
 import com.aliyun.hitsdb.client.value.JSONValue;
 
 import java.util.List;
+import java.util.Map;
 
 public class MetricTimeRange extends JSONValue {
     private String metric;
+    /**
+     * Optional tags input parameters.
+     * added for TSDB v2.4.1 because newly added optional "tags" in api/delete_data
+     */
+    private Map<String, String> tags;
     /**
      * Optional fields input parameters.
      * If provided, we only delete data that belong to provided fields.
@@ -19,15 +25,21 @@ public class MetricTimeRange extends JSONValue {
     }
 
     public MetricTimeRange(String metric, long start, long end) {
-        super();
-        this.metric = metric;
-        this.start = start;
-        this.end = end;
+        this(metric, null, null, start, end);
     }
 
     public MetricTimeRange(String metric, List<String> fields, long start, long end) {
+        this(metric, null, fields, start, end);
+    }
+
+    public MetricTimeRange(String metric, Map<String, String> tags, long start, long end) {
+        this(metric, tags, null, start, end);
+    }
+
+    public MetricTimeRange(String metric, Map<String, String> tags, List<String> fields, long start, long end) {
         super();
         this.metric = metric;
+        this.tags = tags;
         this.fields = fields;
         this.start = start;
         this.end = end;
@@ -40,6 +52,10 @@ public class MetricTimeRange extends JSONValue {
     public void setMetric(String metric) {
         this.metric = metric;
     }
+
+    public Map<String, String> getTags() { return tags; }
+
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
 
     public List<String> getFields() {
         return fields;

--- a/src/test/java/com/aliyun/hitsdb/client/TestHiTSDBClientDeleteData.java
+++ b/src/test/java/com/aliyun/hitsdb/client/TestHiTSDBClientDeleteData.java
@@ -1,29 +1,66 @@
 package com.aliyun.hitsdb.client;
 
 import java.io.IOException;
-import java.util.Date;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import com.aliyun.hitsdb.client.value.request.Point;
+import com.aliyun.hitsdb.client.value.request.Query;
+import com.aliyun.hitsdb.client.value.request.SubQuery;
+import com.aliyun.hitsdb.client.value.response.QueryResult;
+import com.aliyun.hitsdb.client.value.type.Aggregator;
+import org.junit.*;
 
-import com.aliyun.hitsdb.client.HiTSDB;
-import com.aliyun.hitsdb.client.HiTSDBClientFactory;
 import com.aliyun.hitsdb.client.exception.http.HttpClientInitException;
 import com.aliyun.hitsdb.client.util.DateUtils;
+import org.junit.runners.MethodSorters;
 
+@FixMethodOrder(MethodSorters.JVM)
 public class TestHiTSDBClientDeleteData {
     HiTSDB tsdb;
     
     @Before
-    public void init() throws HttpClientInitException {
+    public void init() throws HttpClientInitException, InterruptedException {
         tsdb = HiTSDBClientFactory.connect("127.0.0.1", 8242);
+
+        Date now = DateUtils.now();
+
+        Date ts = DateUtils.add(now, - TimeUnit.DAYS.toMillis(5));
+        Random random = new Random();
+
+        int i;
+        for (i = 0; i < 3; i++) {
+            double radval = random.nextDouble() * 100;
+            Point point = Point
+                    .metric("hello")
+                    .tag("tag1", "val1")
+                    .tag("tag2", "val2")
+                    .timestamp(ts.getTime()+ i * 1000)
+                    .value(radval)
+                    .build();
+            tsdb.putSync(point);
+        }
+
+        for (i = 0; i < 3; i++) {
+            double radval = random.nextDouble() * 100;
+            Point point = Point
+                    .metric("hello")
+                    .tag("tag3", "val3")
+                    .tag("tag4", "val4")
+                    .timestamp(ts.getTime() + i * 1000)
+                    .value(radval)
+                    .build();
+            tsdb.putSync(point);
+        }
+        Thread.sleep(5000);
     }
 
     @After
     public void after() {
         try {
+            Date now = DateUtils.now();
+            Date start = DateUtils.add(now, - TimeUnit.DAYS.toMillis(10));
+            tsdb.deleteData("hello", start, now);
             tsdb.close();
         } catch (IOException e) {
             e.printStackTrace();
@@ -31,19 +68,83 @@ public class TestHiTSDBClientDeleteData {
     }
     
     @Test
-    public void testDeleteData() {
+    public void testDeleteDataWithTags() {
         Date now = DateUtils.now();
         Date start = DateUtils.add(now, - TimeUnit.DAYS.toMillis(10));
-        tsdb.deleteData("hello", start, now);;
+        HashMap<String, String> tags = new HashMap<String, String>();
+        tags.put("tag1", "val1");
+        tags.put("tag2", "val2");
+        tsdb.deleteData("hello", tags, start, now);
+
+        Query query = Query
+                .timeRange(start.getTime(), now.getTime())
+                .msResolution(true)
+                .sub(SubQuery.metric("hello")
+                        .aggregator(Aggregator.NONE)
+                        .tag(tags)
+                        .build())
+                .build();
+        List<QueryResult> result = tsdb.query(query);
+        Assert.assertTrue(result.isEmpty());
+
+        HashMap<String, String> restTags = new HashMap<String, String>();
+        restTags.put("tag3", "val3");
+        restTags.put("tag4", "val4");
+        query = Query
+                .timeRange(start.getTime(), now.getTime())
+                .msResolution(true)
+                .sub(SubQuery.metric("hello")
+                        .aggregator(Aggregator.NONE)
+                        .tag(restTags)
+                        .build())
+                .build();
+        result = tsdb.query(query);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(3, result.get(0).getDps().size());
+
+        restTags.clear();
+        restTags.put("tag3", "val3");
+        query = Query
+                .timeRange(start.getTime(), now.getTime())
+                .msResolution(true)
+                .sub(SubQuery.metric("hello")
+                        .aggregator(Aggregator.NONE)
+                        .tag(restTags)
+                        .build())
+                .build();
+        result = tsdb.query(query);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(3, result.get(0).getDps().size());
+    }
+
+    @Test
+    public void testDeleteDataWithPartialTag() {
+        Date now = DateUtils.now();
+        Date start = DateUtils.add(now, -TimeUnit.DAYS.toMillis(10));
+        HashMap<String, String> tags = new HashMap<String, String>();
+        tags.put("tag1", "val1");
+        tsdb.deleteData("hello", tags, start, now);
+
+        tags.put("tag2", "val2");
+        Query query = Query
+                .timeRange(start.getTime(), now.getTime())
+                .msResolution(true)
+                .sub(SubQuery.metric("hello")
+                        .aggregator(Aggregator.NONE)
+                        .tag(tags)
+                        .build())
+                .build();
+        List<QueryResult> result = tsdb.query(query);
+        Assert.assertTrue(result.isEmpty());
     }
     
-    @Test
+    @Test(expected = com.aliyun.hitsdb.client.exception.http.HttpServerNotSupportException.class)
     public void testDeleteDataForTime() {
         Date now = DateUtils.now();
         Date start = DateUtils.add(now, - TimeUnit.DAYS.toMillis(10));
         int nowTime = DateUtils.toTimestampSecond(now);
         int startTime = DateUtils.toTimestampSecond(start);
-        tsdb.deleteData("hello", nowTime, startTime);;
+        tsdb.deleteData("hello", nowTime, startTime);
     }
     
 }


### PR DESCRIPTION
In the upcoming AliTSDB v2.4.1, the `api/delete_data` will support an optional field "tags". 
Therefore, as the SDK, `HiTSDB#deleteData()` should support the "tags" as its argument.